### PR TITLE
Rebuild as Table Dojo: Next.js 16 + Express 5 + TypeScript monorepo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,5 +47,8 @@ jobs:
           NEXT_PUBLIC_API_URL: http://localhost:5000
           API_INTERNAL_URL: http://localhost:5000
 
+      # `--include=prod` resets the include list that the root .npmrc sets to
+      # `dev`; without it that setting cancels `--omit=dev` and the audit would
+      # also flag dev-only tooling that never ships.
       - name: Audit production dependencies
-        run: npm audit --omit=dev --audit-level=high
+        run: npm audit --include=prod --omit=dev --audit-level=high

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,10 @@
+# Install devDependencies even when NODE_ENV=production.
+#
+# Render and Vercel set NODE_ENV=production during the build, and npm treats
+# that as an implicit --omit=dev. This repo is TypeScript: `typescript` and
+# `@types/*` are devDependencies, so omitting them makes every build fail with
+# "Cannot find type definition file for 'node'" or a cascade of TS2307s.
+#
+# The built output in dist/ and .next/ is plain JavaScript, so the runtime
+# still needs only the regular dependencies — this affects the build only.
+include=dev

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -58,9 +58,15 @@ The repo has a [`render.yaml`](render.yaml) blueprint.
 ## 3. Web — Vercel
 
 1. Vercel → **Add New → Project** → import this repo.
-2. **Root Directory: `apps/web`.** This is the one setting that matters. Vercel detects the npm
-   workspace and installs from the repo root; the `prebuild` script compiles
-   `@tabledojo/game-logic` before `next build`.
+2. **Root Directory: `apps/web`.**
+
+   > This is not optional and it is easy to miss — it is on the import screen under
+   > *Build and Output Settings*, and it defaults to the repo root. Leave it at the root and Vercel
+   > runs the root `npm run build`, which builds the API too, then fails looking for `.next` in the
+   > wrong place. If the build log shows `/vercel/path0/apps/api`, this is the setting to change.
+
+   With it set, Vercel still installs from the repo root (it detects the npm workspace) and the
+   `prebuild` script compiles `@tabledojo/game-logic` before `next build`.
 3. Environment variables:
 
    | Variable | Value |
@@ -115,6 +121,27 @@ CONTACT_TO=you@example.com
 ```
 
 ---
+
+## Troubleshooting
+
+**`Cannot find type definition file for 'node'` (TS2688), or a wall of `Cannot find module
+'@tabledojo/game-logic'` (TS2307).**
+The build installed without devDependencies. Both platforms set `NODE_ENV=production` during the
+build, and npm treats that as an implicit `--omit=dev` — which drops `typescript` and `@types/*`,
+because those are devDependencies. The root [`.npmrc`](.npmrc) sets `include=dev` to override it, and
+`render.yaml` passes `--include=dev` explicitly. If you replaced either, put it back. On Vercel you
+can force it with an Install Command of `npm install --include=dev`.
+
+**Vercel build log mentions `apps/api`.** Root Directory is not set to `apps/web`. See step 3.
+
+**Vercel deploys but the browser calls `localhost:5000`.** `NEXT_PUBLIC_*` is inlined at build time.
+Set it, then redeploy.
+
+**Render deploys but every request 500s.** Check the logs for the Zod message naming the missing
+variable — most often `MONGODB_URI`. The app refuses to boot on bad config rather than failing later.
+
+**Login works for you but not in Safari.** Cookie is cross-site. Either finish step 4 or set
+`COOKIE_SAMESITE=none` while you are still on the platform hostnames.
 
 ## Gotchas
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ npm run dev:web                                   # http://localhost:3000
 | `npm run typecheck` | Type-check all workspaces |
 | `npm run lint` / `npm run format` | ESLint 9 flat config / Prettier |
 
+> The root [`.npmrc`](.npmrc) sets `include=dev` so builds work on hosts that export
+> `NODE_ENV=production` — npm otherwise skips devDependencies, and `typescript` lives there.
+
 ## Deployment
 
 Runs at **$0/month**: Vercel Hobby (web) + Render free instance (API) + MongoDB Atlas free cluster.

--- a/render.yaml
+++ b/render.yaml
@@ -19,7 +19,12 @@ services:
 
     # Builds from the repo root so npm workspaces resolve, and builds the rules
     # package first because the API imports its compiled output.
-    buildCommand: npm ci && npm run build --workspace @tabledojo/game-logic && npm run build --workspace @tabledojo/api
+    #
+    # --include=dev is required: NODE_ENV=production below makes npm omit
+    # devDependencies, which is where typescript and @types/node live. The
+    # root .npmrc sets this too; it is repeated here so the reason is visible
+    # at the point of use.
+    buildCommand: npm ci --include=dev && npm run build --workspace @tabledojo/game-logic && npm run build --workspace @tabledojo/api
     startCommand: node apps/api/dist/server.js
 
     healthCheckPath: /health


### PR DESCRIPTION
Rewrites the site as an npm-workspaces monorepo and reframes it from a virtual casino into a training site for casino table games.

```
packages/game-logic/   Pure TS rules engine — 115 tests
apps/api/              Express 5 + Mongoose 8 REST API — 22 tests
apps/web/              Next.js 16 App Router + Tailwind 4 — 23 routes
```

The original was Express 4 + EJS on Node 14 (EOL), with game logic written as ~1,800 lines of imperative DOM manipulation over module-level globals, wired up with inline `onclick` and `window.fn = fn`. The behaviour was worth keeping; almost none of the code was.

## The architectural idea

Practice mode runs the rules **in the browser** — instant, free, no round trip. Ranked mode runs *the same code* **on the server**, which owns the shoe, the dice and the coin balance. One implementation, two trust levels. That is the entire reason for the `game-logic` package boundary.

## Security

- **Games are server-authoritative.** The browser used to compute its own winnings and `PUT` a new coin balance back, which the server wrote as given — anyone could set their balance from the console, so the leaderboard was decorative. The server now deals, rolls, scores and moves coins; the client only sends decisions.
- **Password reset verifies ownership.** The old flow set a flag and redirected to `/forgotpass?userId=<the user's real id>`; anyone with that URL could set a new password. Now a 32-byte single-use token, stored only as a SHA-256 digest, expiring after an hour, mailed to the address on file.
- **Account enumeration closed.** "Forgot username" returned the username in the response body given an email, phone and birthday. It now emails the address on file and always answers identically.
- Removed `app.use('/javascripts', express.static('node_modules'))`, which served the entire dependency tree to the public.
- Hard-coded session secret and Sentry DSN moved into Zod-validated env config.
- Passwords upgraded PBKDF2 → scrypt, **with transparent migration**: legacy `passport-local-mongoose` hashes still verify and are re-hashed on next sign-in, so existing accounts keep working without a forced reset.
- Added helmet, CORS allow-listing, body size limits, rate limiting on credential and contact routes, and session-ID rotation on login.
- Post bodies are plain text. The blog stored raw Quill HTML and re-injected it with `innerHTML` — a stored-XSS vector on every post.
- Post and comment edit/delete check ownership server-side. Previously only the template hid the buttons.

## Correctness

- **Login streaks** compared date strings built by slicing `Date.prototype.toString()` at fixed offsets, and shipped with a `// this situation may be off` comment. Now whole UTC days, unit-tested across month and year boundaries.
- **Account updates** fired several un-awaited `findOneAndUpdate` calls and used `res.setTimeout(400, …)` to guess when they had finished — a slow write was simply lost. Now one validated write.
- **Comments were addressed by array index**, so deleting one shifted every later index and the next edit hit the wrong comment. They have their own IDs now, embedded in the post so deletes cannot orphan them.
- **The leaderboard** loaded every user into memory, sorted them, then walked two arrays in a nested loop to rank search results. Now an indexed, paged query; search input is escaped before reaching a `RegExp`.
- **The profanity filter** ran only client-side, shipped 200 literal strings on every page load, and matched bare substrings — "class", "assist" and "Scunthorpe" were all rejected. Now server-side, separating substring-safe terms from word-boundary-only ones.
- **The contact form never sent anything.** The route waited 500ms and re-rendered with a success banner.

## Product

- **Blackjack added**, with a basic-strategy engine that grades every practice decision and explains the reasoning. It is the right game for teaching because correct play is a solved problem. The `/learn` strategy chart is *generated from that engine*, so the documentation cannot drift from the game.
- Routes organised into `/practice` (free, hints), `/compete` (ranked, coins) and `/learn` (rules and strategy).
- Slots dropped from the blog boards, matching the table-games-only scope.

## Frontend

EJS templates and 1,381 lines of hand-written CSS replaced with React components and a Tailwind token system. Native `<dialog>` for modals, replacing the hand-rolled implementation and its polyfill. Nav dropdowns are keyboard-reachable and close on Escape and outside click; they were `:hover`-only. Form errors are tied to inputs with `aria-describedby`/`aria-invalid`. Added a skip link, visible focus styles and `prefers-reduced-motion` support. Dates go through `Intl` rather than string slicing.

## Deployment

Configured for $0/month — Vercel Hobby + Render free instance + Atlas free cluster. `render.yaml`, `DEPLOYMENT.md` and GitHub Actions CI included.

The free API instance suspends after 15 minutes idle, so the frontend absorbs it: SSR pages fail soft rather than dying with the serverless function, and a slow first call raises a "waking up" notice instead of hanging. Verified with the API fully down — every page returns 200, and the home page, guides and all three practice tables stay fully usable.

## Verification

137 tests, typecheck, lint, production build of all three workspaces, and a clean production `npm audit` — all green in CI.

## Known trade-offs

- Farkle's house scoring table is preserved exactly as the original computed it, including three 1s scoring 300 rather than the more common 1,000. One constant in `packages/game-logic/src/farkle.ts` changes it.
- The blog lost its rich-text editor along with the stored-XSS vector. Markdown with a sanitizer is the safe way to bring formatting back.
- API tests cover the pure, security-critical units (password hashing and legacy verification, login bonus, profanity). Route-level integration tests need a MongoDB instance and are not written yet.
- Tutorial mode is scaffolding: the strategy engine, grading and `/learn` routes exist; guided step-by-step lessons do not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8qG5BYWyBdcXyfCyXs19f

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8qG5BYWyBdcXyfCyXs19f)_